### PR TITLE
Search/input elements missing labels

### DIFF
--- a/src/Form/Element/DateTime.php
+++ b/src/Form/Element/DateTime.php
@@ -28,30 +28,37 @@ class DateTime extends Element
                 'min' => TimestampDataType::YEAR_MIN,
                 'max' => TimestampDataType::YEAR_MAX,
                 'placeholder' => 'Year', // @translate
+                'aria-label' => 'Year', // @translate
             ]);
         $this->monthElement = (new Element\Select('month'))
             ->setAttribute('class', 'numeric-datetime-month')
             ->setEmptyOption('Month') // @translate
+            ->setAttribute('aria-label', 'Month') // @translate
             ->setValueOptions($this->getMonthValueOptions());
         $this->dayElement = (new Element\Select('day'))
             ->setAttribute('class', 'numeric-datetime-day')
             ->setEmptyOption('Day') // @translate
+            ->setAttribute('aria-label', 'Day') // @translate
             ->setValueOptions($this->getDayValueOptions());
         $this->hourElement = (new Element\Select('hour'))
             ->setAttribute('class', 'numeric-datetime-hour')
             ->setEmptyOption('Hour') // @translate
+            ->setAttribute('aria-label', 'Hour') // @translate
             ->setValueOptions($this->getHourValueOptions());
         $this->minuteElement = (new Element\Select('minute'))
             ->setAttribute('class', 'numeric-datetime-minute')
             ->setEmptyOption('Minute') // @translate
+            ->setAttribute('aria-label', 'Minute') // @translate
             ->setValueOptions($this->getMinuteSecondValueOptions());
         $this->secondElement = (new Element\Select('second'))
             ->setAttribute('class', 'numeric-datetime-second')
             ->setEmptyOption('Second') // @translate
+            ->setAttribute('aria-label', 'Second') // @translate
             ->setValueOptions($this->getMinuteSecondValueOptions());
         $this->offsetElement = (new Element\Select('offset'))
             ->setAttribute('class', 'numeric-datetime-offset')
             ->setEmptyOption('Offset') // @translate
+            ->setAttribute('aria-label', 'Offset') // @translate
             ->setValueOptions($this->getOffsetValueOptions());
     }
 

--- a/src/Form/Element/Duration.php
+++ b/src/Form/Element/Duration.php
@@ -28,6 +28,7 @@ class Duration extends Element
             'step' => 1,
             'min' => 0,
             'placeholder' => 'Years', // @translate
+            'aria-label' => 'Years', // @translate
         ]);
 
         $this->monthsElement = new Element\Number('months');
@@ -36,6 +37,7 @@ class Duration extends Element
             'step' => 1,
             'min' => 0,
             'placeholder' => 'Months', // @translate
+            'aria-label' => 'Months', // @translate
         ]);
 
         $this->daysElement = new Element\Number('days');
@@ -44,6 +46,7 @@ class Duration extends Element
             'step' => 1,
             'min' => 0,
             'placeholder' => 'Days', // @translate
+            'aria-label' => 'Days', // @translate
         ]);
 
         $this->hoursElement = new Element\Number('hours');
@@ -52,6 +55,7 @@ class Duration extends Element
             'step' => 1,
             'min' => 0,
             'placeholder' => 'Hours', // @translate
+            'aria-label' => 'Hours', // @translate
         ]);
 
         $this->minutesElement = new Element\Number('minutes');
@@ -60,6 +64,7 @@ class Duration extends Element
             'step' => 1,
             'min' => 0,
             'placeholder' => 'Minutes', // @translate
+            'aria-label' => 'Minutes', // @translate
         ]);
 
         $this->secondsElement = new Element\Number('seconds');
@@ -68,6 +73,7 @@ class Duration extends Element
             'step' => 1,
             'min' => 0,
             'placeholder' => 'Seconds', // @translate
+            'aria-label' => 'Seconds', // @translate
         ]);
     }
 

--- a/src/Form/Element/Integer.php
+++ b/src/Form/Element/Integer.php
@@ -21,6 +21,7 @@ class Integer extends Element
                 'step' => 1,
                 'min' => IntegerDataType::MIN_SAFE_INT,
                 'max' => IntegerDataType::MAX_SAFE_INT,
+                'aria-label' => 'Value', // @translate
             ]);
     }
 

--- a/view/common/numeric-data-types-advanced-search.phtml
+++ b/view/common/numeric-data-types-advanced-search.phtml
@@ -16,6 +16,7 @@ $this->headLink()->appendStylesheet($this->assetUrl('css/numeric-data-types.css'
         echo $this->numericPropertySelect([
             'name' => 'numeric[ts][gte][pid]',
             'attributes' => [
+                'aria-label' => $this->translate('Property'),
                 'id' => 'timestamp-on-after-pid',
                 'class' => 'chosen-select',
                 'value' => $query['numeric']['ts']['gte']['pid'] ?? null,
@@ -40,6 +41,7 @@ $this->headLink()->appendStylesheet($this->assetUrl('css/numeric-data-types.css'
         echo $this->numericPropertySelect([
             'name' => 'numeric[ts][lte][pid]',
             'attributes' => [
+                'aria-label' => $this->translate('Property'),
                 'id' => 'timestamp-on-before-pid',
                 'class' => 'chosen-select',
                 'value' => $query['numeric']['ts']['lte']['pid'] ?? null,
@@ -62,6 +64,7 @@ $this->headLink()->appendStylesheet($this->assetUrl('css/numeric-data-types.css'
     <div class="inputs">
         <?php
         echo $this->numericPropertySelect([
+            'aria-label' => $this->translate('Property'),
             'name' => 'numeric[dur][gt][pid]',
             'attributes' => [
                 'class' => 'chosen-select',
@@ -85,6 +88,7 @@ $this->headLink()->appendStylesheet($this->assetUrl('css/numeric-data-types.css'
     <div class="inputs">
         <?php
         echo $this->numericPropertySelect([
+            'aria-label' => $this->translate('Property'),
             'name' => 'numeric[dur][lt][pid]',
             'attributes' => [
                 'class' => 'chosen-select',
@@ -108,6 +112,7 @@ $this->headLink()->appendStylesheet($this->assetUrl('css/numeric-data-types.css'
     <div class="inputs">
         <?php
         echo $this->numericPropertySelect([
+            'aria-label' => $this->translate('Property'),
             'name' => 'numeric[ivl][pid]',
             'attributes' => [
                 'id' => 'interval-pid',
@@ -132,6 +137,7 @@ $this->headLink()->appendStylesheet($this->assetUrl('css/numeric-data-types.css'
     <div class="inputs">
         <?php
         echo $this->numericPropertySelect([
+            'aria-label' => $this->translate('Property'),
             'name' => 'numeric[int][gt][pid]',
             'attributes' => [
                 'class' => 'chosen-select',
@@ -155,6 +161,7 @@ $this->headLink()->appendStylesheet($this->assetUrl('css/numeric-data-types.css'
     <div class="inputs">
         <?php
         echo $this->numericPropertySelect([
+            'aria-label' => $this->translate('Property'),
             'name' => 'numeric[int][lt][pid]',
             'attributes' => [
                 'class' => 'chosen-select',

--- a/view/common/numeric-duration.phtml
+++ b/view/common/numeric-duration.phtml
@@ -1,6 +1,8 @@
 <?php
 $this->headLink()->appendStylesheet($this->assetUrl('css/numeric-data-types.css', 'NumericDataTypes'));
 $this->headScript()->appendFile($this->assetUrl('js/numeric-data-types.js', 'NumericDataTypes'));
+$formNumber = clone($this->plugin('formNumber'));
+$formNumber->addTranslatableAttribute('aria-label');
 ?>
 <div class="numeric-duration">
     <div class="error invalid-value"
@@ -10,15 +12,15 @@ $this->headScript()->appendFile($this->assetUrl('js/numeric-data-types.js', 'Num
     <?php echo $this->formHidden($element->getValueElement()); ?>
     <div class="numeric-datetime-inputs">
         <div class="numeric-date-inputs">
-            <?php echo $this->formNumber($element->getYearsElement()); ?>
-            <?php echo $this->formNumber($element->getMonthsElement()); ?>
-            <?php echo $this->formNumber($element->getDaysElement()); ?>
+            <?php echo $formNumber($element->getYearsElement()); ?>
+            <?php echo $formNumber($element->getMonthsElement()); ?>
+            <?php echo $formNumber($element->getDaysElement()); ?>
             <label class="numeric-toggle-time button" aria-title="<?php echo $this->translate('Time'); ?>" title="<?php echo $this->translate('Time'); ?>"><input type="checkbox" name="numeric-toggle-time-checkbox"/></label>
         </div>
         <div class="numeric-time-inputs">
-            <?php echo $this->formNumber($element->getHoursElement()); ?>
-            <?php echo $this->formNumber($element->getMinutesElement()); ?>
-            <?php echo $this->formNumber($element->getSecondsElement()); ?>
+            <?php echo $formNumber($element->getHoursElement()); ?>
+            <?php echo $formNumber($element->getMinutesElement()); ?>
+            <?php echo $formNumber($element->getSecondsElement()); ?>
         </div>
     </div>
 </div>

--- a/view/common/numeric-duration.phtml
+++ b/view/common/numeric-duration.phtml
@@ -15,7 +15,7 @@ $formNumber->addTranslatableAttribute('aria-label');
             <?php echo $formNumber($element->getYearsElement()); ?>
             <?php echo $formNumber($element->getMonthsElement()); ?>
             <?php echo $formNumber($element->getDaysElement()); ?>
-            <label class="numeric-toggle-time button" aria-title="<?php echo $this->translate('Time'); ?>" title="<?php echo $this->translate('Time'); ?>"><input type="checkbox" name="numeric-toggle-time-checkbox"/></label>
+            <label class="numeric-toggle-time button" title="<?php echo $this->translate('Time'); ?>"><input type="checkbox" name="numeric-toggle-time-checkbox" aria-label="<?php echo $this->translate('Time'); ?>"></label>
         </div>
         <div class="numeric-time-inputs">
             <?php echo $formNumber($element->getHoursElement()); ?>

--- a/view/common/numeric-integer.phtml
+++ b/view/common/numeric-integer.phtml
@@ -1,6 +1,8 @@
 <?php
 $this->headLink()->appendStylesheet($this->assetUrl('css/numeric-data-types.css', 'NumericDataTypes'));
 $this->headScript()->appendFile($this->assetUrl('js/numeric-data-types.js', 'NumericDataTypes'));
+$formNumber = clone($this->plugin('formNumber'));
+$formNumber->addTranslatableAttribute('aria-label');
 ?>
 <div class="numeric-integer">
     <div class="error invalid-value"
@@ -9,6 +11,6 @@ $this->headScript()->appendFile($this->assetUrl('js/numeric-data-types.js', 'Num
     </div>
     <?php echo $this->formHidden($element->getValueElement()); ?>
     <div class="numeric-integer-inputs">
-        <?php echo $this->formNumber($element->getIntegerElement()); ?>
+        <?php echo $formNumber($element->getIntegerElement()); ?>
     </div>
 </div>

--- a/view/common/numeric-interval.phtml
+++ b/view/common/numeric-interval.phtml
@@ -18,7 +18,7 @@ $formSelect->addTranslatableAttribute('aria-label');
             <?php echo $formNumber($element->getYearElement()); ?>
             <?php echo $formSelect($element->getMonthElement()); ?>
             <?php echo $formSelect($element->getDayElement()); ?>
-            <label class="numeric-toggle-time button" aria-title="<?php echo $this->translate('Time'); ?>" title="<?php echo $this->translate('Time'); ?>"><input type="checkbox" name="numeric-toggle-time-checkbox"/></label>
+            <label class="numeric-toggle-time button" title="<?php echo $this->translate('Time'); ?>"><input type="checkbox" name="numeric-toggle-time-checkbox" aria-label="<?php echo $this->translate('Time'); ?>"></label>
         </div>
         <div class="numeric-time-inputs">
             <?php echo $formSelect($element->getHourElement()); ?>
@@ -33,7 +33,7 @@ $formSelect->addTranslatableAttribute('aria-label');
             <?php echo $formNumber($element->getYearElement()); ?>
             <?php echo $formSelect($element->getMonthElement()); ?>
             <?php echo $formSelect($element->getDayElement()); ?>
-            <label class="numeric-toggle-time button" aria-title="<?php echo $this->translate('Time'); ?>" title="<?php echo $this->translate('Time'); ?>"><input type="checkbox" name="numeric-toggle-time-checkbox"/></label>
+            <label class="numeric-toggle-time button" title="<?php echo $this->translate('Time'); ?>"><input type="checkbox" name="numeric-toggle-time-checkbox" aria-label="<?php echo $this->translate('Time'); ?>"></label>
         </div>
         <div class="numeric-time-inputs">
             <?php echo $formSelect($element->getHourElement()); ?>

--- a/view/common/numeric-interval.phtml
+++ b/view/common/numeric-interval.phtml
@@ -1,6 +1,10 @@
 <?php
 $this->headLink()->appendStylesheet($this->assetUrl('css/numeric-data-types.css', 'NumericDataTypes'));
 $this->headScript()->appendFile($this->assetUrl('js/numeric-data-types.js', 'NumericDataTypes'));
+$formNumber = clone($this->plugin('formNumber'));
+$formNumber->addTranslatableAttribute('aria-label');
+$formSelect = clone($this->plugin('formSelect'));
+$formSelect->addTranslatableAttribute('aria-label');
 ?>
 <div class="numeric-interval">
     <div class="error invalid-value"
@@ -11,31 +15,31 @@ $this->headScript()->appendFile($this->assetUrl('js/numeric-data-types.js', 'Num
     <div class="numeric-datetime-inputs numeric-interval-start">
         <span><?php echo $this->translate('Start:'); ?></span>
         <div class="numeric-date-inputs">
-            <?php echo $this->formNumber($element->getYearElement()); ?>
-            <?php echo $this->formSelect($element->getMonthElement()); ?>
-            <?php echo $this->formSelect($element->getDayElement()); ?>
+            <?php echo $formNumber($element->getYearElement()); ?>
+            <?php echo $formSelect($element->getMonthElement()); ?>
+            <?php echo $formSelect($element->getDayElement()); ?>
             <label class="numeric-toggle-time button" aria-title="<?php echo $this->translate('Time'); ?>" title="<?php echo $this->translate('Time'); ?>"><input type="checkbox" name="numeric-toggle-time-checkbox"/></label>
         </div>
         <div class="numeric-time-inputs">
-            <?php echo $this->formSelect($element->getHourElement()); ?>
-            <?php echo $this->formSelect($element->getMinuteElement()); ?>
-            <?php echo $this->formSelect($element->getSecondElement()); ?>
-            <?php echo $this->formSelect($element->getOffsetElement()); ?>
+            <?php echo $formSelect($element->getHourElement()); ?>
+            <?php echo $formSelect($element->getMinuteElement()); ?>
+            <?php echo $formSelect($element->getSecondElement()); ?>
+            <?php echo $formSelect($element->getOffsetElement()); ?>
         </div>
     </div>
     <div class="numeric-datetime-inputs numeric-interval-end">
         <span><?php echo $this->translate('End:'); ?></span>
         <div class="numeric-date-inputs">
-            <?php echo $this->formNumber($element->getYearElement()); ?>
-            <?php echo $this->formSelect($element->getMonthElement()); ?>
-            <?php echo $this->formSelect($element->getDayElement()); ?>
+            <?php echo $formNumber($element->getYearElement()); ?>
+            <?php echo $formSelect($element->getMonthElement()); ?>
+            <?php echo $formSelect($element->getDayElement()); ?>
             <label class="numeric-toggle-time button" aria-title="<?php echo $this->translate('Time'); ?>" title="<?php echo $this->translate('Time'); ?>"><input type="checkbox" name="numeric-toggle-time-checkbox"/></label>
         </div>
         <div class="numeric-time-inputs">
-            <?php echo $this->formSelect($element->getHourElement()); ?>
-            <?php echo $this->formSelect($element->getMinuteElement()); ?>
-            <?php echo $this->formSelect($element->getSecondElement()); ?>
-            <?php echo $this->formSelect($element->getOffsetElement()); ?>
+            <?php echo $formSelect($element->getHourElement()); ?>
+            <?php echo $formSelect($element->getMinuteElement()); ?>
+            <?php echo $formSelect($element->getSecondElement()); ?>
+            <?php echo $formSelect($element->getOffsetElement()); ?>
         </div>
     </div>
 </div>

--- a/view/common/numeric-timestamp.phtml
+++ b/view/common/numeric-timestamp.phtml
@@ -1,6 +1,10 @@
 <?php
 $this->headLink()->appendStylesheet($this->assetUrl('css/numeric-data-types.css', 'NumericDataTypes'));
 $this->headScript()->appendFile($this->assetUrl('js/numeric-data-types.js', 'NumericDataTypes'));
+$formNumber = clone($this->plugin('formNumber'));
+$formNumber->addTranslatableAttribute('aria-label');
+$formSelect = clone($this->plugin('formSelect'));
+$formSelect->addTranslatableAttribute('aria-label');
 ?>
 <div class="numeric-timestamp">
     <div class="error invalid-value"
@@ -10,16 +14,16 @@ $this->headScript()->appendFile($this->assetUrl('js/numeric-data-types.js', 'Num
     <?php echo $this->formHidden($element->getValueElement()); ?>
     <div class="numeric-datetime-inputs">
         <div class="numeric-date-inputs">
-            <?php echo $this->formNumber($element->getYearElement()); ?>
-            <?php echo $this->formSelect($element->getMonthElement()); ?>
-            <?php echo $this->formSelect($element->getDayElement()); ?>
+            <?php echo $formNumber($element->getYearElement()); ?>
+            <?php echo $formSelect($element->getMonthElement()); ?>
+            <?php echo $formSelect($element->getDayElement()); ?>
             <label class="numeric-toggle-time button" aria-title="<?php echo $this->translate('Time'); ?>" title="<?php echo $this->translate('Time'); ?>"><input type="checkbox" name="numeric-toggle-time-checkbox"/></label>
         </div>
         <div class="numeric-time-inputs">
-            <?php echo $this->formSelect($element->getHourElement()); ?>
-            <?php echo $this->formSelect($element->getMinuteElement()); ?>
-            <?php echo $this->formSelect($element->getSecondElement()); ?>
-            <?php echo $this->formSelect($element->getOffsetElement()); ?>
+            <?php echo $formSelect($element->getHourElement()); ?>
+            <?php echo $formSelect($element->getMinuteElement()); ?>
+            <?php echo $formSelect($element->getSecondElement()); ?>
+            <?php echo $formSelect($element->getOffsetElement()); ?>
         </div>
     </div>
 </div>

--- a/view/common/numeric-timestamp.phtml
+++ b/view/common/numeric-timestamp.phtml
@@ -17,7 +17,7 @@ $formSelect->addTranslatableAttribute('aria-label');
             <?php echo $formNumber($element->getYearElement()); ?>
             <?php echo $formSelect($element->getMonthElement()); ?>
             <?php echo $formSelect($element->getDayElement()); ?>
-            <label class="numeric-toggle-time button" aria-title="<?php echo $this->translate('Time'); ?>" title="<?php echo $this->translate('Time'); ?>"><input type="checkbox" name="numeric-toggle-time-checkbox"/></label>
+            <label class="numeric-toggle-time button" title="<?php echo $this->translate('Time'); ?>"><input type="checkbox" name="numeric-toggle-time-checkbox" aria-label="<?php echo $this->translate('Time'); ?>"></label>
         </div>
         <div class="numeric-time-inputs">
             <?php echo $formSelect($element->getHourElement()); ?>


### PR DESCRIPTION
Numeric Data Types has lots of "compound" form elements where the standard label only really applies to the group and not any single element. Mostly these lack any explicit labeling, instead using default selections or the placeholder attribute.

This PR adds aria-labels to all inputs missing them, and also corrects a minor problem with the existing labels used for the "Time" checkboxes.

To ease this process, the PR uses the Laminas form helper ability to set additional attributes as translatable, so we don't need to plumb a translator into the form classes. To prevent this setting from affecting all later calls to the same helper, the code used here clones the form helpers before doing so.