### PR TITLE
Fixed display of integer according to standards.

### DIFF
--- a/src/DataType/Integer.php
+++ b/src/DataType/Integer.php
@@ -75,7 +75,10 @@ class Integer extends AbstractDataType implements ValueAnnotatingInterface
         if (!$this->isValid(['@value' => $value->value()])) {
             return $value->value();
         }
-        return number_format($value->value());
+        // The last argument is a narrow no-break space.
+        // @see https://www.php.net/manual/en/function.number_format.php#126944
+        // @see https://en.wikipedia.org/wiki/International_System_of_Units#cite_ref-generalrules_105-0
+        return number_format($value->value(), 0, ',', ' ');
     }
 
     public function getEntityClass()


### PR DESCRIPTION
According to standards, the thousand separator should not be a ",", but a space or a thin space: see general rules in https://en.wikipedia.org/wiki/International_System_of_Units#cite_ref-generalrules_105-0 . In fact, the comma is rarely used on Earth, except by American people.